### PR TITLE
Fix NullReferenceException being thrown if parameterized test has one…

### DIFF
--- a/Allure/Commons/Helpers/ReportHelper.cs
+++ b/Allure/Commons/Helpers/ReportHelper.cs
@@ -50,10 +50,12 @@ namespace Allure.Commons.Helpers
                 for (var i = 0; i < listOfArgs.Count; i++)
                 {
                     var paramNum = i + 1;
-                    var strArg = listOfArgs[i].ToString();
+                    var arg = listOfArgs[i];
+                    var strArg = arg != null ? arg.ToString() : "null";
+                    var argType = arg != null ? arg.GetType().Name : "Unknown";
                     var param = new Parameter
                     {
-                        name = $"Parameter #{paramNum}, {listOfArgs[i].GetType().Name}",
+                        name = $"Parameter #{paramNum}, {argType}",
                         value = hideParams.Contains(paramNum) ? "Parameter is hidden" : strArg
                     };
                     if (removeParams.Contains(paramNum)) continue;

--- a/TestsSamples/Debugging.cs
+++ b/TestsSamples/Debugging.cs
@@ -89,5 +89,11 @@ namespace TestsSamples
         {
             AllureLifecycle.Instance.Verify.That("This is parametrized step", 5, Is.GreaterThan(2), login, password);
         }
+
+        [TestCase("5th Avenue", 10, null)]
+        public void TestWithNullParameter(string street, int houseNUmber, int? apartment)
+        {
+            AllureLifecycle.Instance.Verify.That("This is parametrized step with null parameter", !apartment.HasValue);
+        }
     }
 }


### PR DESCRIPTION
… of the parameter value equal null.